### PR TITLE
Misc CI improvements

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,8 @@
 name: ci
 
-on: [push, pull_request]
+on:
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   ci:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         include:
           - name: gcc-static
-            os: ubuntu-22.04
+            os: ubuntu-24.04
             compiler: gcc
             generator: Ninja
             cmake-args: "-DBUILD_SHARED_LIBS=OFF"
@@ -42,7 +42,7 @@ jobs:
             generator: Ninja
             cmake-args: "-DBUILD_SHARED_LIBS=OFF"
           - name: clang-dynamic
-            os: ubuntu-22.04
+            os: ubuntu-24.04
             compiler: clang
             generator: Ninja
             cmake-args: "-DBUILD_SHARED_LIBS=ON"
@@ -56,7 +56,7 @@ jobs:
             generator: Visual Studio 17 2022
             cmake-args: -A Win32
           - name: msvc-x64
-            os: windows-2022
+            os: windows-2025
             generator: Visual Studio 17 2022
             cmake-args: -A x64
           - name: clang-cl-x64

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+# https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions
+permissions:
+  contents: read
+
 jobs:
   ci:
     name: ${{ matrix.name }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -87,3 +87,7 @@ jobs:
 
       - run: (cd build && ctest -C Debug )
         if: startsWith(matrix.os, 'windows')
+
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true


### PR DESCRIPTION
* Only run CI jobs for PRs or when manually triggered
* Reduce CI permissions
* Only allow 1 ongoing run per branch
* Bump a few of the jobs to newer OSes